### PR TITLE
Role check partially implemented, without pulling email from Auth0 db.

### DIFF
--- a/auth0CheckUser.tsx
+++ b/auth0CheckUser.tsx
@@ -7,9 +7,15 @@ type roleAndAllowed = {
 }
 
 /*
+    We will need to wrap the useUser hook that the auth0 package gives us: https://github.com/auth0/nextjs-auth0#consume-authentication
+
+    Basically, we need our own hook that will call that hook, use user.email to load the info we have in our database, and  then thats the user object that we return
+
+    To write custom hooks: https://react.dev/learn/reusing-logic-with-custom-hooks
+
     Explaination:
         This function SHOULD be implemented within every route except the initial '/' route.
-        It checks the see if a user is logged in, otherwise it redirects them to the initial 
+        It checks the see if a user is logged in, otherwise it redirects them to the initial DONE
         ('login') page. Also checks to see if the user is the correct role otherwise they are
         redirected to the login page.
     Parameter:
@@ -20,15 +26,15 @@ type roleAndAllowed = {
     Implementation:
         if(!CheckUser(["Admin"])) return(<div>Redirecting...</div>);
 */
+
+
 export default function CheckUser(rolesAllowed?: String[]) : roleAndAllowed {
     const { user, error, isLoading } = useUser();
     const router = useRouter();
 
-    if (isLoading) return <div>Loading...</div>;
-
-    if (error) return(<div>{error.message}</div>);
-
-    if (!user) {
+    //if the individual is not a user, 
+    if (!user)
+    {
         router.push('/api/auth/login?returnTo=/');
         return{
             'allowed': false,
@@ -36,32 +42,28 @@ export default function CheckUser(rolesAllowed?: String[]) : roleAndAllowed {
         };
     }
 
-    /*
-        ------------------------------------------------------------------------------
-        INSERT CODE that connects to database and gets user's ROLE from NAME and EMAIL
-        ------------------------------------------------------------------------------
-    */
+    //Need to write code to pull the user's email from Auth0's database, and then pass that email as an argument to check what role that email is tied to within our ATC database
 
-    var role
-    // ideally this would fetch role from prsima database
-    //if(user.email == 'guerbray@gmail.com')
-        role = 'Admin'
-    //else
-     //   role = "Technician"
 
-    // if any of the users are allowed, return true and send the role
-    //for(const roleAllowed of rolesAllowed) {
-    //    if (roleAllowed == role)
-            return{
-                'allowed': true, 
-                'role': role,
-            };
-    //}
+    const typedUser = User;
 
-    // else, send to the login screen
-   /*  router.push('/api/auth/logout');
-    return{
-        'allowed': false,
-        'role': null,
-    }; */
+    // Check if the user's role is not included in the specified roles
+    if (
+        rolesAllowed &&
+        rolesAllowed.length > 0 &&
+        typedUser.EmployeeProfile &&
+        !rolesAllowed.includes(typedUser.EmployeeProfile.role)
+    ) {
+        router.push('/unauthorized'); // Redirect to an unauthorized page or handle it accordingly
+        return {
+            'allowed': false,
+            'role': typedUser.EmployeeProfile.role,
+        };
+    }
+
+    // If the user's role is allowed or there is no role information
+    return {
+        'allowed': true,
+        'role': typedUser.EmployeeProfile ? typedUser.EmployeeProfile.role : null,
+    };
 }


### PR DESCRIPTION
Currently redirects if user is not part of ATC organization to login/register pages. Implemented condition to check if user is part of ATC, but user's role does not match role parameters. Need to specify page it redirects to.

Couldn't fetch email from Auth0's database, and then pass that email as an argument to check what role that email is tied to within our ATC database for this step. 
